### PR TITLE
Fix subscription receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v0.1.0
+
+### Fixed
+
+- Remove json encoding from `CustomerReceipt` field in `SubscriptionsCreateRequestBuilder` and `SubscriptionsUpdateRequestBuilder` ([#7])
+
+[#7]: https://github.com/avto-dev/cloud-payments-laravel/issues/7
+
 ## v0.0.2
 
 ### Changed

--- a/src/Requests/Subscriptions/SubscriptionsCreateRequestBuilder.php
+++ b/src/Requests/Subscriptions/SubscriptionsCreateRequestBuilder.php
@@ -287,7 +287,7 @@ class SubscriptionsCreateRequestBuilder extends AbstractRequestBuilder
             'Period'              => $this->period,
             'MaxPeriods'          => $this->max_periods,
             'CustomerReceipt'     => $this->customer_receipt instanceof Receipt
-                ? Json::encode($this->customer_receipt->toArray())
+                ? $this->customer_receipt->toArray()
                 : null,
         ];
     }

--- a/src/Requests/Subscriptions/SubscriptionsCreateRequestBuilder.php
+++ b/src/Requests/Subscriptions/SubscriptionsCreateRequestBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace AvtoDev\CloudPayments\Requests\Subscriptions;
 
 use DateTime;
-use Psy\Util\Json;
 use DateTimeInterface;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;

--- a/src/Requests/Subscriptions/SubscriptionsUpdateRequestBuilder.php
+++ b/src/Requests/Subscriptions/SubscriptionsUpdateRequestBuilder.php
@@ -231,7 +231,7 @@ class SubscriptionsUpdateRequestBuilder extends AbstractRequestBuilder
             'Period'              => $this->period,
             'MaxPeriods'          => $this->max_periods,
             'CustomerReceipt'     => $this->customer_receipt instanceof Receipt
-                ? Json::encode($this->customer_receipt->toArray())
+                ? $this->customer_receipt->toArray()
                 : null,
         ];
     }

--- a/src/Requests/Subscriptions/SubscriptionsUpdateRequestBuilder.php
+++ b/src/Requests/Subscriptions/SubscriptionsUpdateRequestBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace AvtoDev\CloudPayments\Requests\Subscriptions;
 
 use DateTime;
-use Psy\Util\Json;
 use DateTimeInterface;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\UriInterface;

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsCreateRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsCreateRequestBuilderTest.php
@@ -71,7 +71,7 @@ class SubscriptionsCreateRequestBuilderTest extends AbstractRequestBuilderTestCa
         $this->request_builder->setCustomerReceipt($receipt);
 
         $this->assertSame(
-            Json::encode(['CustomerReceipt' => Json::encode($receipt->toArray())]),
+            Json::encode(['CustomerReceipt' => $receipt->toArray()]),
             $this->request_builder->buildRequest()->getBody()->getContents()
         );
     }

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsUpdateRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsUpdateRequestBuilderTest.php
@@ -70,7 +70,7 @@ class SubscriptionsUpdateRequestBuilderTest extends AbstractRequestBuilderTestCa
         $this->request_builder->setCustomerReceipt($receipt);
 
         $this->assertSame(
-            Json::encode(['CustomerReceipt' => Json::encode($receipt->toArray())]),
+            Json::encode(['CustomerReceipt' => $receipt->toArray()]),
             $this->request_builder->buildRequest()->getBody()->getContents()
         );
     }


### PR DESCRIPTION
| Q                    | A
| ------------------ | ---
| Bug fix?          | Yes
| New feature?  | No

## Description

Remove json encoding from `CustomerReceipt` field in `SubscriptionsCreateRequestBuilder` and `SubscriptionsUpdateRequestBuilder`

Fixes #7 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/cloud-payments-laravel/blob/master/CHANGELOG.md) file
