### PR TITLE
Laravel 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,19 +26,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '7.3'
             setup: basic
             coverage: no
-            laravel: '~5.6.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^6.0'
+            laravel: '^7.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: composer require --dev --update-with-all-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
 
       - name: Show most important packages versions
         run: composer info | grep -e laravel -e phpunit -e phpstan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.0
+
+### Changed
+
+- Laravel 8 is supported
+- Guzzle 7 (`guzzlehttp/guzzle`) is supported
+- Dependency `tarampampam/wrappers-php` version `~2.0` is supported
+
 ## v1.0.1
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Laravel 8 is supported
+- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
 - Guzzle 7 (`guzzlehttp/guzzle`) is supported
 - Dependency `tarampampam/wrappers-php` version `~2.0` is supported
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM php:7.2.5-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-2.9.6 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,10 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
-.PHONY : help build latest install lowest test test-cover 'shell' clean
+.PHONY : help build latest install lowest test test-cover shell clean
 .DEFAULT_GOAL : help
 
 # This will output the help for each task. thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -16,26 +14,25 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) composer test
+	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	$(dc_bin) run -e "PS1=\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]" \
-	    $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package provides easy way to use [Cloud Payments API](https://developers.clo
 Require this package with composer using the following command:
 
 ```shell
-$ composer require avto-dev/cloud-payments-laravel "^1.0"
+$ composer require avto-dev/cloud-payments-laravel "^1.1"
 ```
 
 > Installed `composer` is required ([how to install composer][getcomposer]).
@@ -27,8 +27,7 @@ $ composer require avto-dev/cloud-payments-laravel "^1.0"
 
 > You can find laravel framework integration [here](#frameworks-integration)
 
-For client configuration use `Config` instance. It constructor require **Public ID** and **API Secret**
-that you can find in ClodPayments personal area.
+For client configuration use `Config` instance. Client constructor requires **Public ID** and **API Secret** that you can find in ClodPayments personal area.
 
 ```php
 use AvtoDev\CloudPayments\Config;

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "~6.1",
+        "guzzlehttp/guzzle": "~6.1 || ~7.0",
         "guzzlehttp/psr7": "^1.4",
         "psr/http-client": "~1.0",
-        "tarampampam/wrappers-php": "^1.5"
+        "tarampampam/wrappers-php": "^1.5 || ~2.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.9",
-        "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "~7.5",
-        "tarampampam/guzzle-url-mock": "^1.1"
+        "phpunit/phpunit": "^8.0",
+        "tarampampam/guzzle-url-mock": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      PS1: '\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'
     volumes:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro

--- a/src/Exceptions/CloudPaymentsRequestException.php
+++ b/src/Exceptions/CloudPaymentsRequestException.php
@@ -10,11 +10,12 @@ use GuzzleHttp\Exception\RequestException;
 class CloudPaymentsRequestException extends RequestException
 {
     /**
-     * {@inheritdoc}
+     * @param RequestInterface $request
+     * @param \Exception       $e
      *
      * @return CloudPaymentsRequestException
      */
-    public static function wrapException(RequestInterface $request, \Exception $e)
+    public static function wrapException(RequestInterface $request, $e): RequestException
     {
         return $e instanceof self
             ? $e


### PR DESCRIPTION
## Description

### Changed

- Laravel 8 is supported
- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
- Guzzle 7 (`guzzlehttp/guzzle`) is supported
- Dependency `tarampampam/wrappers-php` version `~2.0` is supported

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
