### PR TITLE
Added support for PHP 8 and composer 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   php:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup, laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4']
+        php: ['7.2', '7.3', '7.4', '8.0']
         include:
           - php: '7.3'
             setup: basic
@@ -35,8 +35,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring
-          tools: composer:v1 # TODO update composer up to v2
+          extensions: mbstring, xdebug
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
@@ -49,22 +48,19 @@ jobs: # Docs: <https://git.io/JvxXE>
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Install Composer 'hirak/prestissimo' package
-        run: composer global require hirak/prestissimo --update-no-dev --no-progress --ansi
-
       - name: Install lowest Composer dependencies
         if: matrix.setup == 'lowest'
-        run: composer update --prefer-dist --no-suggest --prefer-lowest --ansi
+        run: composer update --prefer-dist --prefer-lowest --ansi
 
       - name: Install basic Composer dependencies
         if: matrix.setup == 'basic'
-        run: composer update --prefer-dist --no-suggest --ansi
+        run: composer update --prefer-dist --ansi
 
       - name: Install specific laravel version
         if: matrix.laravel != 'default'
-        run: composer require --dev --update-with-all-dependencies --prefer-dist --no-suggest --ansi laravel/laravel "${{ matrix.laravel }}"
+        run: composer require --dev --update-with-dependencies --prefer-dist --ansi laravel/laravel "${{ matrix.laravel }}"
 
-      - name: Show most important packages versions
+      - name: Show most important package versions
         run: composer info | grep -e laravel -e phpunit -e phpstan
 
       - name: Execute tests
@@ -73,6 +69,8 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Execute tests with code coverage
         if: matrix.coverage == 'yes'
+        env:
+          XDEBUG_MODE: coverage
         run: composer test-cover
 
       - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
@@ -85,7 +83,7 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support PHP `8.x`
+
+### Changed
+
+- Composer `2.x` is supported now
+- Package `fzaninotto/faker` replaced with `fakerphp/faker` version `^1.12`
+
 ## v1.1.0
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM php:7.3.5-alpine
+FROM php:8.0-alpine
 
-ENV \
-    COMPOSER_ALLOW_SUPERUSER="1" \
-    COMPOSER_HOME="/tmp/composer"
+ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.6 1>/dev/null \
+    && pecl install xdebug-3.0.0 1>/dev/null \
     && apk del .build-deps \
-    && mkdir /src ${COMPOSER_HOME} \
-    && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \
+    && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \
-    && chmod -R 777 ${COMPOSER_HOME} \
     && composer --version \
     && php -v \
     && php -m

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-cover: ## Execute php tests with coverage
 	docker-compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	docker-compose run $(RUN_APP_ARGS) app shAbstractRequestTest::testRequestId
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,22 @@ build: ## Build docker images, required for current package environment
 	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist
 
 lowest: clean ## Install lowest php dependencies
-	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
 	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" -e 'XDEBUG_MODE=coverage' app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	docker-compose run $(RUN_APP_ARGS) app sh
+	docker-compose run $(RUN_APP_ARGS) app shAbstractRequestTest::testRequestId
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.1 || ~7.0",
         "guzzlehttp/psr7": "^1.4",
@@ -16,11 +16,11 @@
         "tarampampam/wrappers-php": "^1.5 || ~2.0"
     },
     "require-dev": {
-        "fzaninotto/faker": "^1.9",
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
-        "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^8.0",
-        "tarampampam/guzzle-url-mock": "^1.3"
+        "phpunit/phpunit": "^8.0 || ^9.3",
+        "tarampampam/guzzle-url-mock": "^1.3",
+        "fakerphp/faker": "^1.12",
+        "phpstan/phpstan": "~0.12.34"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,11 +2,14 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
+         backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          bootstrap="./tests/bootstrap.php"
+         processIsolation="false"
+         forceCoversAnnotation="true"
          stopOnFailure="false">
     <testsuites>
         <testsuite name="Feature">
@@ -17,6 +20,7 @@
         </testsuite>
     </testsuites>
 
+    <!-- deprecated -->
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
@@ -25,11 +29,27 @@
             </exclude>
         </whitelist>
     </filter>
-
     <logging>
         <!--<log type="coverage-html" target="./coverage/html"/>-->
         <log type="coverage-xml" target="./coverage/xml"/>
         <log type="coverage-clover" target="./coverage/clover.xml"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
     </logging>
+    <!-- /deprecated -->
+
+    <coverage includeUncoveredFiles="false" processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <directory>./vendor</directory>
+            <directory>./tests</directory>
+        </exclude>
+        <report>
+            <clover outputFile="./coverage/clover.xml"/>
+            <html outputDirectory="./coverage/html"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+            <xml outputDirectory="./coverage/xml"/>
+        </report>
+    </coverage>
 </phpunit>

--- a/tests/Unit/Requests/AbstractRequestBuilderTestCase.php
+++ b/tests/Unit/Requests/AbstractRequestBuilderTestCase.php
@@ -28,9 +28,6 @@ abstract class AbstractRequestBuilderTestCase extends AbstractTestCase
         $this->uri             = $this->getUri();
     }
 
-    /**
-     * @covers ::getUri
-     */
     public function testUri(): void
     {
         $uri = $this->request_builder->buildRequest()->getUri();

--- a/tests/Unit/Requests/AbstractRequestTest.php
+++ b/tests/Unit/Requests/AbstractRequestTest.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\RequestInterface;
 use AvtoDev\CloudPayments\Requests\AbstractRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\AbstractRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\AbstractRequestBuilder
  */
 class AbstractRequestTest extends AbstractTestCase
 {
@@ -44,10 +44,6 @@ class AbstractRequestTest extends AbstractTestCase
         };
     }
 
-    /**
-     * @covers ::buildRequest
-     * @covers ::setRequestId
-     */
     public function testRequestId(): void
     {
         $request = $this->request_builder->buildRequest();
@@ -63,9 +59,6 @@ class AbstractRequestTest extends AbstractTestCase
         $this->assertSame($request_id, $request->getHeader('X-Request-ID')[0]);
     }
 
-    /**
-     * @covers ::buildRequest
-     */
     public function testUriResolve(): void
     {
         $request = $this->request_builder->buildRequest();
@@ -81,9 +74,6 @@ class AbstractRequestTest extends AbstractTestCase
         $this->assertSame('example.com', $request->getUri()->getHost());
     }
 
-    /**
-     * @covers ::buildRequest
-     */
     public function testBuildRequest(): void
     {
         $request = $this->request_builder->buildRequest();

--- a/tests/Unit/Requests/ApplePay/ApplePayStartSessionRequestBuilderTest.php
+++ b/tests/Unit/Requests/ApplePay/ApplePayStartSessionRequestBuilderTest.php
@@ -12,7 +12,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\ApplePay\ApplePayStartSessionRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\ApplePay\ApplePayStartSessionRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\ApplePay\ApplePayStartSessionRequestBuilder
  */
 class ApplePayStartSessionRequestBuilderTest extends AbstractRequestBuilderTestCase
 {
@@ -21,10 +21,6 @@ class ApplePayStartSessionRequestBuilderTest extends AbstractRequestBuilderTestC
      */
     protected $request_builder;
 
-    /**
-     * @covers ::getRequestPayload
-     * @covers ::setValidationUrl
-     */
     public function testSetValidationUrl(): void
     {
         $request_builder = $this->getRequestBuilder();

--- a/tests/Unit/Requests/Payments/Cards/CardsAuthRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/Cards/CardsAuthRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Payments\Cards\CardsAuthRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\Cards\CardsAuthRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\Cards\CardsAuthRequestBuilder
  */
 class CardsAuthRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Payments/Cards/CardsChargeRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/Cards/CardsChargeRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\CloudPayments\Requests\Payments\Cards\CardsAuthRequestBuilder;
 use AvtoDev\CloudPayments\Requests\Payments\Cards\CardsChargeRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\Cards\CardsChargeRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\Cards\CardsChargeRequestBuilder
  */
 class CardsChargeRequestBuilderTest extends CardsAuthRequestBuilderTest
 {

--- a/tests/Unit/Requests/Payments/Cards/CardsPost3DsRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/Cards/CardsPost3DsRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Payments\Cards\CardsPost3DsRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\Cards\CardsPost3DsRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\Cards\CardsPost3DsRequestBuilder
  */
 class CardsPost3DsRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Payments/PaymentsConfirmRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/PaymentsConfirmRequestBuilderTest.php
@@ -11,7 +11,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Payments\PaymentsConfirmRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\PaymentsConfirmRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\PaymentsConfirmRequestBuilder
  */
 class PaymentsConfirmRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Payments/PaymentsVoidRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/PaymentsVoidRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Payments\PaymentsVoidRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\PaymentsVoidRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\PaymentsVoidRequestBuilder
  */
 class PaymentsVoidRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Payments/Tokens/TokensAuthRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/Tokens/TokensAuthRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensAuthRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensAuthRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensAuthRequestBuilder
  */
 class TokensAuthRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Payments/Tokens/TokensChargeRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/Tokens/TokensChargeRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensAuthRequestBuilder;
 use AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensChargeRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensChargeRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Payments\Tokens\TokensChargeRequestBuilder
  */
 class TokensChargeRequestBuilderTest extends TokensAuthRequestBuilderTest
 {

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsCancelRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsCancelRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsCancelRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsCancelRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsCancelRequestBuilder
  */
 class SubscriptionsCancelRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsCreateRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsCreateRequestBuilderTest.php
@@ -14,7 +14,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsCreateRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsCreateRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsCreateRequestBuilder
  */
 class SubscriptionsCreateRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsFindRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsFindRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsFindRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsFindRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsFindRequestBuilder
  */
 class SubscriptionsFindRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsGetRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsGetRequestBuilderTest.php
@@ -10,7 +10,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsGetRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsGetRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsGetRequestBuilder
  */
 class SubscriptionsGetRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsUpdateRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsUpdateRequestBuilderTest.php
@@ -14,7 +14,7 @@ use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsUpdateRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsUpdateRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\Subscriptions\SubscriptionsUpdateRequestBuilder
  */
 class SubscriptionsUpdateRequestBuilderTest extends AbstractRequestBuilderTestCase
 {

--- a/tests/Unit/Requests/TestRequestBuilderTest.php
+++ b/tests/Unit/Requests/TestRequestBuilderTest.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\UriInterface;
 use AvtoDev\CloudPayments\Requests\TestRequestBuilder;
 
 /**
- * @coversDefaultClass \AvtoDev\CloudPayments\Requests\TestRequestBuilder
+ * @covers \AvtoDev\CloudPayments\Requests\TestRequestBuilder
  */
 class TestRequestBuilderTest extends AbstractRequestBuilderTestCase
 {


### PR DESCRIPTION
## Description

<!--

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

-->

### Added

- Support PHP `8.x`

### Changed

- Composer `2.x` is supported now
- Package `fzaninotto/faker` replaced with `fakerphp/faker` version `^1.12`

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
