### PR TITLE
Remove tarampampam/wrappers-php and replace tarampampam/guzzle-url-mock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0']
         include:
           - php: '7.3'
             setup: basic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
+- Minimal require PHP version now is `7.3`
 - Package `tarampampam/guzzle-url-mock` replaced with `avto-dev/guzzle-url-mock` version `^1.5`
 
 ## v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Removed
+
+- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed
+
+### Changed
+
+- Package `tarampampam/guzzle-url-mock` replaced with `avto-dev/guzzle-url-mock` version `^1.5`
+
 ## v1.2.0
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,14 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.1 || ~7.0",
         "guzzlehttp/psr7": "^1.4",
-        "psr/http-client": "~1.0",
-        "tarampampam/wrappers-php": "^1.5 || ~2.0"
+        "psr/http-client": "~1.0"
     },
     "require-dev": {
         "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "phpunit/phpunit": "^8.0 || ^9.3",
-        "tarampampam/guzzle-url-mock": "^1.3",
         "fakerphp/faker": "^1.12",
-        "phpstan/phpstan": "~0.12.34"
+        "phpstan/phpstan": "~0.12.34",
+        "avto-dev/guzzle-url-mock": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.1 || ~7.0",
         "guzzlehttp/psr7": "^1.4",

--- a/src/Requests/AbstractRequestBuilder.php
+++ b/src/Requests/AbstractRequestBuilder.php
@@ -60,7 +60,7 @@ abstract class AbstractRequestBuilder
 
         if ($request_data !== []) {
             /** @var RequestInterface $request */
-            $request = $request->withBody(stream_for(\json_encode($request_data,JSON_THROW_ON_ERROR)));
+            $request = $request->withBody(stream_for(\json_encode($request_data, JSON_THROW_ON_ERROR)));
         }
 
         return $request;

--- a/src/Requests/AbstractRequestBuilder.php
+++ b/src/Requests/AbstractRequestBuilder.php
@@ -35,6 +35,8 @@ abstract class AbstractRequestBuilder
     }
 
     /**
+     * @throws \JsonException
+     *
      * @return RequestInterface
      */
     public function buildRequest(): RequestInterface
@@ -58,7 +60,7 @@ abstract class AbstractRequestBuilder
 
         if ($request_data !== []) {
             /** @var RequestInterface $request */
-            $request = $request->withBody(stream_for(\json_encode($request_data)));
+            $request = $request->withBody(stream_for(\json_encode($request_data,JSON_THROW_ON_ERROR)));
         }
 
         return $request;

--- a/src/Requests/AbstractRequestBuilder.php
+++ b/src/Requests/AbstractRequestBuilder.php
@@ -6,7 +6,6 @@ namespace AvtoDev\CloudPayments\Requests;
 
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\Request;
-use Tarampampam\Wrappers\Json;
 use GuzzleHttp\Psr7\UriResolver;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\RequestInterface;
@@ -36,8 +35,6 @@ abstract class AbstractRequestBuilder
     }
 
     /**
-     * @throws \Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException
-     *
      * @return RequestInterface
      */
     public function buildRequest(): RequestInterface
@@ -61,7 +58,7 @@ abstract class AbstractRequestBuilder
 
         if ($request_data !== []) {
             /** @var RequestInterface $request */
-            $request = $request->withBody(stream_for(Json::encode($request_data)));
+            $request = $request->withBody(stream_for(\json_encode($request_data)));
         }
 
         return $request;

--- a/src/Requests/Payments/Cards/CardsAuthRequestBuilder.php
+++ b/src/Requests/Payments/Cards/CardsAuthRequestBuilder.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\UriInterface;
 use AvtoDev\CloudPayments\Requests\Traits\HasReceipt;
 use AvtoDev\CloudPayments\Requests\AbstractRequestBuilder;
 use AvtoDev\CloudPayments\Requests\Traits\PaymentRequestTrait;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 /**
  * @see https://developers.cloudpayments.ru/#oplata-po-kriptogramme
@@ -62,8 +61,6 @@ class CardsAuthRequestBuilder extends AbstractRequestBuilder
 
     /**
      * {@inheritdoc}
-     *
-     * @throws JsonEncodeDecodeException
      */
     protected function getRequestPayload(): array
     {

--- a/src/Requests/Payments/PaymentsConfirmRequestBuilder.php
+++ b/src/Requests/Payments/PaymentsConfirmRequestBuilder.php
@@ -5,11 +5,9 @@ declare(strict_types = 1);
 namespace AvtoDev\CloudPayments\Requests\Payments;
 
 use GuzzleHttp\Psr7\Uri;
-use Tarampampam\Wrappers\Json;
 use Psr\Http\Message\UriInterface;
 use AvtoDev\CloudPayments\Requests\Traits\HasReceipt;
 use AvtoDev\CloudPayments\Requests\AbstractRequestBuilder;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 /**
  * @see https://developers.cloudpayments.ru/#podtverzhdenie-oplaty
@@ -79,8 +77,6 @@ class PaymentsConfirmRequestBuilder extends AbstractRequestBuilder
 
     /**
      * {@inheritdoc}
-     *
-     * @throws JsonEncodeDecodeException
      */
     protected function getRequestPayload(): array
     {
@@ -90,7 +86,7 @@ class PaymentsConfirmRequestBuilder extends AbstractRequestBuilder
             'TransactionId' => $this->transaction_id,
             'Amount'        => $this->amount,
             'JsonData'      => $this->json_data !== null && $this->json_data !== []
-                ? Json::encode($this->json_data)
+                ? \json_encode($this->json_data)
                 : null,
         ];
     }

--- a/src/Requests/Payments/PaymentsConfirmRequestBuilder.php
+++ b/src/Requests/Payments/PaymentsConfirmRequestBuilder.php
@@ -77,6 +77,7 @@ class PaymentsConfirmRequestBuilder extends AbstractRequestBuilder
 
     /**
      * {@inheritdoc}
+     *
      * @throws \JsonException
      */
     protected function getRequestPayload(): array

--- a/src/Requests/Payments/PaymentsConfirmRequestBuilder.php
+++ b/src/Requests/Payments/PaymentsConfirmRequestBuilder.php
@@ -77,6 +77,7 @@ class PaymentsConfirmRequestBuilder extends AbstractRequestBuilder
 
     /**
      * {@inheritdoc}
+     * @throws \JsonException
      */
     protected function getRequestPayload(): array
     {
@@ -86,7 +87,7 @@ class PaymentsConfirmRequestBuilder extends AbstractRequestBuilder
             'TransactionId' => $this->transaction_id,
             'Amount'        => $this->amount,
             'JsonData'      => $this->json_data !== null && $this->json_data !== []
-                ? \json_encode($this->json_data)
+                ? \json_encode($this->json_data, JSON_THROW_ON_ERROR)
                 : null,
         ];
     }

--- a/src/Requests/Payments/Tokens/TokensAuthRequestBuilder.php
+++ b/src/Requests/Payments/Tokens/TokensAuthRequestBuilder.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\UriInterface;
 use AvtoDev\CloudPayments\Requests\Traits\HasReceipt;
 use AvtoDev\CloudPayments\Requests\AbstractRequestBuilder;
 use AvtoDev\CloudPayments\Requests\Traits\PaymentRequestTrait;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
 
 /**
  * @see https://developers.cloudpayments.ru/#oplata-po-tokenu-rekarring
@@ -41,8 +40,6 @@ class TokensAuthRequestBuilder extends AbstractRequestBuilder
 
     /**
      * {@inheritdoc}
-     *
-     * @throws JsonEncodeDecodeException
      */
     protected function getRequestPayload(): array
     {

--- a/src/Requests/Traits/PaymentRequestTrait.php
+++ b/src/Requests/Traits/PaymentRequestTrait.php
@@ -186,7 +186,7 @@ trait PaymentRequestTrait
             'AccountId'   => $this->account_id,
             'Email'       => $this->email,
             'JsonData'    => $this->json_data !== null && $this->json_data !== []
-                ? \json_encode($this->json_data,JSON_THROW_ON_ERROR)
+                ? \json_encode($this->json_data, JSON_THROW_ON_ERROR)
                 : null,
         ]);
     }

--- a/src/Requests/Traits/PaymentRequestTrait.php
+++ b/src/Requests/Traits/PaymentRequestTrait.php
@@ -171,6 +171,8 @@ trait PaymentRequestTrait
     }
 
     /**
+     * @throws \JsonException
+     *
      * @return array<string, float|string>
      */
     protected function getCommonPaymentParams(): array
@@ -184,7 +186,7 @@ trait PaymentRequestTrait
             'AccountId'   => $this->account_id,
             'Email'       => $this->email,
             'JsonData'    => $this->json_data !== null && $this->json_data !== []
-                ? \json_encode($this->json_data)
+                ? \json_encode($this->json_data,JSON_THROW_ON_ERROR)
                 : null,
         ]);
     }

--- a/src/Requests/Traits/PaymentRequestTrait.php
+++ b/src/Requests/Traits/PaymentRequestTrait.php
@@ -4,9 +4,6 @@ declare(strict_types = 1);
 
 namespace AvtoDev\CloudPayments\Requests\Traits;
 
-use Tarampampam\Wrappers\Json;
-use Tarampampam\Wrappers\Exceptions\JsonEncodeDecodeException;
-
 trait PaymentRequestTrait
 {
     /**
@@ -174,8 +171,6 @@ trait PaymentRequestTrait
     }
 
     /**
-     * @throws JsonEncodeDecodeException
-     *
      * @return array<string, float|string>
      */
     protected function getCommonPaymentParams(): array
@@ -189,7 +184,7 @@ trait PaymentRequestTrait
             'AccountId'   => $this->account_id,
             'Email'       => $this->email,
             'JsonData'    => $this->json_data !== null && $this->json_data !== []
-                ? Json::encode($this->json_data)
+                ? \json_encode($this->json_data)
                 : null,
         ]);
     }

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Psr7\Response;
 use AvtoDev\CloudPayments\Client;
 use AvtoDev\CloudPayments\Config;
 use AvtoDev\Tests\AbstractTestCase;
-use Tarampampam\GuzzleUrlMock\UrlsMockHandler;
+use AvtoDev\GuzzleUrlMock\UrlsMockHandler;
 use AvtoDev\CloudPayments\Exceptions\CloudPaymentsRequestException;
 
 /**

--- a/tests/Unit/Frameworks/Laravel/ServiceProviderTest.php
+++ b/tests/Unit/Frameworks/Laravel/ServiceProviderTest.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Foundation\Testing\TestCase;
-use Tarampampam\GuzzleUrlMock\UrlsMockHandler;
+use AvtoDev\GuzzleUrlMock\UrlsMockHandler;
 use AvtoDev\CloudPayments\Frameworks\Laravel\ServiceProvider;
 
 /**

--- a/tests/Unit/Requests/AbstractRequestTest.php
+++ b/tests/Unit/Requests/AbstractRequestTest.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Unit\Requests;
 
 use GuzzleHttp\Psr7\Uri;
-use Tarampampam\Wrappers\Json;
 use Psr\Http\Message\UriInterface;
 use AvtoDev\Tests\AbstractTestCase;
 use Psr\Http\Message\RequestInterface;
@@ -80,7 +79,7 @@ class AbstractRequestTest extends AbstractTestCase
 
         $this->assertInstanceOf(RequestInterface::class, $request);
 
-        $this->assertSame($this->request_builder->params, Json::decode((string) $request->getBody()));
+        $this->assertSame($this->request_builder->params, \json_decode((string) $request->getBody(), true));
         $this->assertSame('application/json', $request->getHeader('Content-Type')[0]);
     }
 }

--- a/tests/Unit/Requests/ApplePay/ApplePayStartSessionRequestBuilderTest.php
+++ b/tests/Unit/Requests/ApplePay/ApplePayStartSessionRequestBuilderTest.php
@@ -6,7 +6,6 @@ namespace Unit\Requests\ApplePay;
 
 use GuzzleHttp\Psr7\Uri;
 use Illuminate\Support\Str;
-use Tarampampam\Wrappers\Json;
 use Psr\Http\Message\UriInterface;
 use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\ApplePay\ApplePayStartSessionRequestBuilder;
@@ -29,7 +28,7 @@ class ApplePayStartSessionRequestBuilderTest extends AbstractRequestBuilderTestC
         $request = $request_builder->buildRequest();
 
         $this->assertJsonStringEqualsJsonString(
-            Json::encode(['ValidationUrl' => $validation_uri]),
+            \json_encode(['ValidationUrl' => $validation_uri]),
             $request->getBody()->getContents()
         );
     }

--- a/tests/Unit/Requests/Payments/PaymentsConfirmRequestBuilderTest.php
+++ b/tests/Unit/Requests/Payments/PaymentsConfirmRequestBuilderTest.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Unit\Requests\Payments;
 
 use GuzzleHttp\Psr7\Uri;
-use Tarampampam\Wrappers\Json;
 use Psr\Http\Message\UriInterface;
 use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
 use AvtoDev\CloudPayments\Requests\Payments\PaymentsConfirmRequestBuilder;
@@ -26,7 +25,7 @@ class PaymentsConfirmRequestBuilderTest extends AbstractRequestBuilderTestCase
 
         $this->request_builder->setTransactionId(123);
 
-        $data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+        $data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('TransactionId', $data);
         $this->assertSame(123, $data['TransactionId']);
@@ -36,7 +35,7 @@ class PaymentsConfirmRequestBuilderTest extends AbstractRequestBuilderTestCase
     {
         $this->request_builder->setAmount(32.1);
 
-        $data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+        $data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('Amount', $data);
         $this->assertSame(32.1, $data['Amount']);
@@ -46,7 +45,7 @@ class PaymentsConfirmRequestBuilderTest extends AbstractRequestBuilderTestCase
     {
         $this->request_builder->setJsonData(['some']);
 
-        $data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+        $data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('JsonData', $data);
         $this->assertSame('["some"]', $data['JsonData']);

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsCreateRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsCreateRequestBuilderTest.php
@@ -7,7 +7,6 @@ namespace AvtoDev\Tests\Unit\Requests\Subscriptions;
 use Carbon\Carbon;
 use GuzzleHttp\Psr7\Uri;
 use Illuminate\Support\Str;
-use Tarampampam\Wrappers\Json;
 use Psr\Http\Message\UriInterface;
 use AvtoDev\CloudPayments\Receipts\Receipt;
 use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
@@ -43,7 +42,7 @@ class SubscriptionsCreateRequestBuilderTest extends AbstractRequestBuilderTestCa
         foreach ($fields as $field => $value) {
             $this->request_builder->{'set' . $field}($value);
 
-            $request_data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+            $request_data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
             $this->assertArrayHasKey($field, $request_data);
             $this->assertSame($value, $request_data[$field]);
         }
@@ -56,7 +55,7 @@ class SubscriptionsCreateRequestBuilderTest extends AbstractRequestBuilderTestCa
 
         $this->request_builder->setStartDate($carbon_now);
 
-        $request_data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+        $request_data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('StartDate', $request_data);
 
@@ -71,7 +70,7 @@ class SubscriptionsCreateRequestBuilderTest extends AbstractRequestBuilderTestCa
         $this->request_builder->setCustomerReceipt($receipt);
 
         $this->assertSame(
-            Json::encode(['CustomerReceipt' => $receipt->toArray()]),
+            \json_encode(['CustomerReceipt' => $receipt->toArray()]),
             $this->request_builder->buildRequest()->getBody()->getContents()
         );
     }

--- a/tests/Unit/Requests/Subscriptions/SubscriptionsUpdateRequestBuilderTest.php
+++ b/tests/Unit/Requests/Subscriptions/SubscriptionsUpdateRequestBuilderTest.php
@@ -7,7 +7,6 @@ namespace AvtoDev\Tests\Unit\Requests\Subscriptions;
 use Carbon\Carbon;
 use GuzzleHttp\Psr7\Uri;
 use Illuminate\Support\Str;
-use Tarampampam\Wrappers\Json;
 use Psr\Http\Message\UriInterface;
 use AvtoDev\CloudPayments\Receipts\Receipt;
 use AvtoDev\Tests\Unit\Requests\AbstractRequestBuilderTestCase;
@@ -42,7 +41,7 @@ class SubscriptionsUpdateRequestBuilderTest extends AbstractRequestBuilderTestCa
         foreach ($fields as $field => $value) {
             $this->request_builder->{'set' . $field}($value);
 
-            $request_data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+            $request_data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
             $this->assertArrayHasKey($field, $request_data);
             $this->assertSame($value, $request_data[$field]);
         }
@@ -55,7 +54,7 @@ class SubscriptionsUpdateRequestBuilderTest extends AbstractRequestBuilderTestCa
 
         $this->request_builder->setStartDate($carbon_now);
 
-        $request_data = Json::decode($this->request_builder->buildRequest()->getBody()->getContents());
+        $request_data = \json_decode($this->request_builder->buildRequest()->getBody()->getContents(), true);
 
         $this->assertArrayHasKey('StartDate', $request_data);
 
@@ -70,7 +69,7 @@ class SubscriptionsUpdateRequestBuilderTest extends AbstractRequestBuilderTestCa
         $this->request_builder->setCustomerReceipt($receipt);
 
         $this->assertSame(
-            Json::encode(['CustomerReceipt' => $receipt->toArray()]),
+            \json_encode(['CustomerReceipt' => $receipt->toArray()]),
             $this->request_builder->buildRequest()->getBody()->getContents()
         );
     }


### PR DESCRIPTION
## Description

### Removed

- Dependency `tarampampam/wrappers-php` because this package was deprecated and removed

### Changed

- Minimal PHP version now is `^7.3`
- Package `tarampampam/guzzle-url-mock` replaced with `avto-dev/guzzle-url-mock` version `^1.5`

Fixes # (issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
