### PR TITLE
feat: add SaveCard, PaymentUrl, CultureName, and Payer parameters in …

### DIFF
--- a/src/References/CultureName.php
+++ b/src/References/CultureName.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\CloudPayments\References;
+
+/**
+ * @see https://developers.cloudpayments.ru/#lokalizatsiya
+ */
+interface CultureName
+{
+    /**
+     * Supported culture names and their respective time zones.
+     */
+    public const
+        RU_RU = 'ru-RU', // Russian, MSK.
+        EN_US = 'en-US', // English, CET.
+        LV = 'lv',       // Latvian, CET.
+        AZ = 'az',       // Azerbaijani, AZT.
+        KK = 'kk',       // Russian, ALMT.
+        UK = 'uk',       // Ukrainian, EET.
+        PL = 'pl',       // Polish, CET.
+        VI = 'vi',       // Vietnamese, ICT.
+        TR = 'tr';       // Turkish, TRT.
+}

--- a/src/References/Payer.php
+++ b/src/References/Payer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AvtoDev\CloudPayments\References;
+
+/**
+ * @see https://developers.cloudpayments.ru/#oplata-po-kriptogramme
+ */
+interface Payer
+{
+    /**
+     * Supported Payer fields and their descriptions.
+     */
+    public const
+        FIRST_NAME  = 'FirstName',  // First name of the payer.
+        LAST_NAME   = 'LastName',   // Last name of the payer.
+        MIDDLE_NAME = 'MiddleName', // Middle name of the payer.
+        BIRTH       = 'Birth',      // Date of birth of the payer.
+        STREET      = 'Street',     // Street address of the payer.
+        ADDRESS     = 'Address',    // Full address of the payer.
+        CITY        = 'City',       // City of the payer.
+        COUNTRY     = 'Country',    // Country of the payer.
+        PHONE       = 'Phone',      // Phone number of the payer.
+        POSTCODE    = 'Postcode';   // Postal code of the payer.
+}

--- a/src/Requests/Payments/Cards/CardsAuthRequestBuilder.php
+++ b/src/Requests/Payments/Cards/CardsAuthRequestBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace AvtoDev\CloudPayments\Requests\Payments\Cards;
 
@@ -27,6 +27,42 @@ class CardsAuthRequestBuilder extends AbstractRequestBuilder
     protected $name;
 
     /**
+     * Save card.
+     *
+     * Card token saving flag for making payment using saved card
+     *
+     * @var bool
+     */
+    protected $save_card;
+
+    /**
+     * Payment Url.
+     *
+     * The address of the site from which the checkout script is called
+     *
+     * @var string
+     */
+    protected $payment_url;
+
+    /**
+     * The primary language in which the API issues messages to the user.
+     *
+     * Default is Russian.
+     * 
+     * @see CultureName
+     *
+     * @var string
+     */
+    protected $culture_name;
+
+    /**
+     * @see Payer
+     * 
+     * @var array<mixed>
+     */
+    protected array $payer = [];
+
+    /**
      * Cryptogram.
      *
      * Required
@@ -46,6 +82,57 @@ class CardsAuthRequestBuilder extends AbstractRequestBuilder
 
         return $this;
     }
+
+    /**
+     * @param string $save_card
+     *
+     * @return CardsAuthRequestBuilder
+     */
+    public function setSaveCard(bool $save_card): self
+    {
+        $this->save_card = $save_card;
+
+        return $this;
+    }
+
+    /**
+     * @param string $payment_url
+     *
+     * @return CardsAuthRequestBuilder
+     */
+    public function setPaymentUrl(string $payment_url): self
+    {
+        $this->payment_url = $payment_url;
+
+        return $this;
+    }
+
+    /**
+     * Required.
+     *
+     * @param string $culture_name
+     *
+     * @return CardsAuthRequestBuilder
+     */
+    public function setCultureName(string $culture_name): self
+    {
+        $this->culture_name = $culture_name;
+
+        return $this;
+    }
+
+    /**
+     * @param array<mixed> $payer
+     *
+     * @return CardsAuthRequestBuilder
+     */
+    public function setPayer(array $payer): self
+    {
+        $this->payer = $payer;
+
+        return $this;
+    }
+
 
     /**
      * @param string $card_cryptogram_packet
@@ -68,7 +155,11 @@ class CardsAuthRequestBuilder extends AbstractRequestBuilder
 
         return \array_merge($this->getCommonPaymentParams(), [
             'Name'                 => $this->name,
+            'SaveCard'             => $this->save_card,
+            'PaymentUrl'           => $this->payment_url,
+            'CultureName'          => $this->culture_name,
             'CardCryptogramPacket' => $this->card_cryptogram_packet,
+            'Payer'                => !empty($this->payer) ? $this->payer : null,
         ]);
     }
 


### PR DESCRIPTION
### feat: add SaveCard, PaymentUrl, CultureName, and Payer parameters in CardsAuthRequestBuilder

## Description

This pull request adds support for new parameters to the `CardsAuthRequestBuilder` class.

### Changes Made:
- **SaveCard**: Added support for saving card tokens for recurring payments.  
- **PaymentUrl**: Added a parameter to specify the URL of the site initiating the checkout script.  
- **CultureName**: Added localization support with values like `ru-RU`, `en-US`, etc. In References added a new interface CultureName with corresponding documentation.
- **Payer**: Added support for passing payer information such as first name, last name, address, phone, etc. In References added a new interface Payer with corresponding documentation.

### Key Updates:
1. Added new properties (`save_card`, `payment_url`, `culture_name`, `payer`) with corresponding setter methods.
2. Extended `getRequestPayload` to include the new parameters in the request payload.
3. Updated documentation and inline comments to describe the new fields and their functionality.

### Dependencies:
No new dependencies were introduced in this change.

Fixes # (issue) <!-- If applicable, add the issue number here -->

---

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I testes my code with test API keys _(if tests are required for my changes)_.